### PR TITLE
RN gimbal roll change

### DIFF
--- a/km_Gimbal.cs
+++ b/km_Gimbal.cs
@@ -221,10 +221,10 @@ namespace km_Gimbal
         }
 
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Roll")]
-        public bool enableRoll = false;
+        public bool enableRoll = true;
 
         [KSPField(isPersistant = true)]
-        private bool autoSetRoll = true;
+        private bool autoSetRoll = false;
 
         [KSPEvent(guiName = "Toggle Roll", guiActive = true, guiActiveEditor = true)]
         public void toggleRoll()


### PR DESCRIPTION
-Change gimbal roll to be on by default. I have observed that almost
every person I have seen use this, streamers, forums users and myself
included always activate roll on all engines immediately in VAB.
The stock gimbals have roll on to begin with. 
This should be an opt-out setting rather than opt-in as there is no harm in having them on but if you forget to turn them on you can have no control of your craft.
